### PR TITLE
Step10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+/gradle.properties
 build/
 !../gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ RequestResponsePact getOneProduct(PactDslWithProvider builder) {
 Let's run and generate an updated pact file on the client:
 
 ```console
-❯ ./gradlew consumer:test --tests *PactTest
+❯ ./gradlew consumer:test --tests '*PactTest'
   
   BUILD SUCCESSFUL in 7s
 ```
@@ -635,7 +635,7 @@ Let's open up our provider Pact verifications in `provider/src/test/java/au/com/
 Let's see how we go now:
 
 ```console
-❯ ./gradlew provider:test --tests *Pact*Test
+❯ ./gradlew provider:test --tests '*Pact*Test'
 
 BUILD SUCCESSFUL in 11s
 ```
@@ -872,7 +872,7 @@ public class ProductConsumerPactTest {
 Generate a new Pact file:
 
 ```console
-❯ ./gradlew consumer:test --tests *PactTest
+❯ ./gradlew consumer:test --tests '*PactTest'
 
 BUILD SUCCESSFUL in 9s
 ```
@@ -886,7 +886,7 @@ Let's test the provider. Copy the updated pact file into the provider's pact dir
   
   BUILD SUCCESSFUL in 1s
 
-❯  ./gradlew provider:test --tests *Pact*Test
+❯  ./gradlew provider:test --tests '*Pact*Test'
 
 ...
 ...
@@ -957,7 +957,7 @@ Authorization: Bearer 2006-01-02T15:04
 Let's test this out:
 
 ```console
-❯ ./gradlew provider:test --tests *Pact*Test
+❯ ./gradlew provider:test --tests '*Pact*Test'
 
 au.com.dius.pactworkshop.provider.ProductPactProviderTest > FrontendApplication - get all products FAILED
     java.lang.AssertionError at ProductPactProviderTest.java:43
@@ -1017,7 +1017,7 @@ In `provider/src/test/java/au/com/dius/pactworkshop/provider/ProductPactProvider
 We can now run the Provider tests
 
 ```console
-❯ ./gradlew provider:test --tests *Pact*Test
+❯ ./gradlew provider:test --tests '*Pact*Test'
 
 BUILD SUCCESSFUL in 1s
 ```

--- a/consumer/src/test/java/au/com/dius/pactworkshop/consumer/ProductConsumerPactRegexTest.java
+++ b/consumer/src/test/java/au/com/dius/pactworkshop/consumer/ProductConsumerPactRegexTest.java
@@ -1,0 +1,48 @@
+package au.com.dius.pactworkshop.consumer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProductConsumerPactRegexTest {
+	@Test
+	void testRegex() {
+		// Expected boundaries
+		assertTrue("Bearer 1900-01-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T10:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T20:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T21:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T22:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T23:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-01-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-09-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-10-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-11-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-09T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-10T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-19T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-20T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-29T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-30T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1900-12-31T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 1999-12-31T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2000-01-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2099-01-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2099-01-01T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2099-12-31T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2099-12-31T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		// Feb 29 - note validity of leap years not checked
+		assertTrue("Bearer 2020-02-29T12:34".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue("Bearer 2021-02-29T12:34".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		// Invalid cases
+		assertTrue(!"Bearer 1899-12-31T23:59".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2100-01-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-13-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-00-01T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-01-32T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-01-00T00:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-01-01T24:00".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+		assertTrue(!"Bearer 2021-01-01T00:60".matches(ProductConsumerPactTest.AUTH_TOKEN_REGEX));
+	}
+}

--- a/consumer/src/test/java/au/com/dius/pactworkshop/consumer/ProductConsumerPactTest.java
+++ b/consumer/src/test/java/au/com/dius/pactworkshop/consumer/ProductConsumerPactTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(PactConsumerTestExt.class)
 public class ProductConsumerPactTest {
+    static final String AUTH_TOKEN_REGEX = "Bearer (19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0123]):[0-5][0-9]";
 
     @Pact(consumer = "FrontendApplication", provider = "ProductService")
     RequestResponsePact getAllProducts(PactDslWithProvider builder) {
@@ -32,7 +33,7 @@ public class ProductConsumerPactTest {
                 .uponReceiving("get all products")
                 .method("GET")
                 .path("/products")
-                .matchHeader("Authorization", "Bearer (19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][1-9]|2[0123]):[0-5][0-9]")
+                .matchHeader("Authorization", AUTH_TOKEN_REGEX)
                 .willRespondWith()
                 .status(200)
                 .headers(headers())
@@ -52,7 +53,7 @@ public class ProductConsumerPactTest {
                 .uponReceiving("get all products")
                 .method("GET")
                 .path("/products")
-                .matchHeader("Authorization", "Bearer (19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][1-9]|2[0123]):[0-5][0-9]")
+                .matchHeader("Authorization", AUTH_TOKEN_REGEX)
                 .willRespondWith()
                 .status(200)
                 .headers(headers())
@@ -77,7 +78,7 @@ public class ProductConsumerPactTest {
                 .uponReceiving("get product with ID 10")
                 .method("GET")
                 .path("/product/10")
-                .matchHeader("Authorization", "Bearer (19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][1-9]|2[0123]):[0-5][0-9]")
+                .matchHeader("Authorization", AUTH_TOKEN_REGEX)
                 .willRespondWith()
                 .status(200)
                 .headers(headers())
@@ -95,7 +96,7 @@ public class ProductConsumerPactTest {
                 .uponReceiving("get product with ID 11")
                 .method("GET")
                 .path("/product/11")
-                .matchHeader("Authorization", "Bearer (19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][1-9]|2[0123]):[0-5][0-9]")
+                .matchHeader("Authorization", AUTH_TOKEN_REGEX)
                 .willRespondWith()
                 .status(404)
                 .toPact();


### PR DESCRIPTION
Intellij complained until I added  `org.gradle.java.home=/Users/REDACTED/.jenv/versions/17.0` to a gradle.properties file.
Added the file to .gitignore.

Fixed READMEs console examples that were missing single quotes around filename patterns used in test commands.

Bearer token timestamp regex didn't allow for the 10 o'clock hour. Updated and slight refactor. Also added regex tests.