### PR TITLE
Step5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+/gradle.properties
 build/
 !../gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ RequestResponsePact getOneProduct(PactDslWithProvider builder) {
 Let's run and generate an updated pact file on the client:
 
 ```console
-❯ ./gradlew consumer:test --tests *PactTest
+❯ ./gradlew consumer:test --tests '*PactTest'
   
   BUILD SUCCESSFUL in 7s
 ```


### PR DESCRIPTION
Intellij complained until I added org.gradle.java.home=/Users/REDACTED/.jenv/versions/17.0 to a gradle.properties file.
Added the file to .gitignore.

Fixed README console examples that were missing single quotes around filename patterns used in test commands.