### PR TITLE
step4: Adding gradle.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+/gradle.properties
 !../gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/


### PR DESCRIPTION
Intellij complained until I added org.gradle.java.home=/Users/REDACTED/.jenv/versions/17.0 to a gradle.properties file.
Added the file to .gitignore.