### PR TITLE
main: Updating README jdk on main. Adding gradle.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+/gradle.properties
 build/
 !../gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ step of the workshop just check out the branch for that step (i.e. `git checkout
 
 ## Requirements
 
-* JDK 8+
+* JDK 17+
 * Docker for step 11
 
 ## Workshop outline:


### PR DESCRIPTION
Updated jdk version required in readme

Intellij complained until I added org.gradle.java.home=/Users/REDACTED/.jenv/versions/17.0 to a gradle.properties file.
Added the file to .gitignore.